### PR TITLE
fix: Missing part in user defined api base

### DIFF
--- a/src/intellichat/services/AnthropicChatService.ts
+++ b/src/intellichat/services/AnthropicChatService.ts
@@ -11,7 +11,7 @@ import {
 } from 'intellichat/types';
 import Anthropic from '../../providers/Anthropic';
 import { isBlank } from 'utils/validators';
-import { getBase64, splitByImg, stripHtmlTags } from 'utils/util';
+import { getBase64, splitByImg, stripHtmlTags, urlJoin } from 'utils/util';
 import INextChatService from './INextCharService';
 import AnthropicReader from 'intellichat/readers/AnthropicReader';
 import NextChatService from './NextChatService';
@@ -200,7 +200,7 @@ export default class AnthropicChatService
     const payload = await this.makePayload(messages);
     debug('About to make a request, payload:\r\n', payload);
     const { base, key } = this.apiSettings;
-    const url = new URL('/v1/messages', base);
+    const url = urlJoin('/v1/messages', base);
     const response = await fetch(url.toString(), {
       method: 'POST',
       headers: {

--- a/src/intellichat/services/AzureChatService.ts
+++ b/src/intellichat/services/AzureChatService.ts
@@ -2,6 +2,7 @@ import OpenAIChatService from './OpenAIChatService';
 import Azure from '../../providers/Azure'
 import { IChatContext, IChatRequestMessage } from 'intellichat/types';
 import INextChatService from './INextCharService';
+import { urlJoin } from 'utils/util';
 
 
 export default class AzureChatService
@@ -16,7 +17,7 @@ export default class AzureChatService
   protected async makeRequest(messages: IChatRequestMessage[]): Promise<Response> {
     const apiVersion = '2024-10-21';
     const { base, deploymentId, key } = this.apiSettings;
-    const url = new URL(`/openai/deployments/${deploymentId}/chat/completions?api-version=${apiVersion}`, base);
+    const url = urlJoin(`/openai/deployments/${deploymentId}/chat/completions?api-version=${apiVersion}`, base);
     const response = await fetch(
       url.toString(),
       {

--- a/src/intellichat/services/BaiduChatService.ts
+++ b/src/intellichat/services/BaiduChatService.ts
@@ -1,7 +1,7 @@
 import Debug from 'debug';
 import Baidu from '../../providers/Baidu';
 import { IChatContext, IChatRequestMessage } from '../types';
-import { date2unix } from 'utils/util';
+import { date2unix, urlJoin } from 'utils/util';
 import INextChatService from './INextCharService';
 import OpenAIChatService from './OpenAIChatService';
 
@@ -116,7 +116,7 @@ export default class BaiduChatService
     const token = await this.geToken();
     payload.model = this.context.getModel().name.toLowerCase();
 
-    const url = `${base}/v2/chat/completions`;
+    const url = urlJoin("/v2/chat/completions", base);
     const response = await fetch(url, {
       method: 'POST',
       headers: {

--- a/src/intellichat/services/ChatBroChatService.ts
+++ b/src/intellichat/services/ChatBroChatService.ts
@@ -8,6 +8,7 @@ import ChatBro from '../../providers/ChatBro';
 import INextChatService from './INextCharService';
 import OpenAIChatService from './OpenAIChatService';
 import ChatBroReader from 'intellichat/readers/ChatBroReader';
+import { urlJoin } from 'utils/util';
 
 const debug = Debug('5ire:intellichat:ChatBroChatService');
 
@@ -46,7 +47,7 @@ export default class ChatBroChatService
     const payload = await this.makePayload(messages);
     debug('About to make a request, payload:\r\n', payload);
     const { base, key } = this.apiSettings;
-    const url = new URL(`/v1/open/azure/chat`, base);
+    const url = urlJoin(`/v1/open/azure/chat`, base);
     const postResp = await fetch(url.toString(), {
       method: 'POST',
       headers: {

--- a/src/intellichat/services/DeepSeekChatService.ts
+++ b/src/intellichat/services/DeepSeekChatService.ts
@@ -2,6 +2,7 @@ import OpenAIChatService from './OpenAIChatService';
 import DeepSeek from '../../providers/DeepSeek';
 import { IChatContext, IChatRequestMessage } from 'intellichat/types';
 import INextChatService from './INextCharService';
+import { urlJoin } from 'utils/util';
 
 export default class DeepSeekChatService
   extends OpenAIChatService
@@ -16,10 +17,7 @@ export default class DeepSeekChatService
     messages: IChatRequestMessage[],
   ): Promise<Response> {
     const { base, key } = this.apiSettings;
-    const url = new URL(
-      'chat/completions',
-      base.endsWith('/') ? base : `${base}/`,
-    );
+    const url = urlJoin('/chat/completions', base)
     const response = await fetch(url.toString(), {
       method: 'POST',
       headers: {

--- a/src/intellichat/services/DoubaoChatService.ts
+++ b/src/intellichat/services/DoubaoChatService.ts
@@ -2,6 +2,7 @@ import OpenAIChatService from './OpenAIChatService';
 import Doubao from '../../providers/Doubao';
 import { IChatContext, IChatRequestMessage } from 'intellichat/types';
 import INextChatService from './INextCharService';
+import { urlJoin } from 'utils/util';
 
 export default class DoubaoChatService
   extends OpenAIChatService
@@ -18,7 +19,7 @@ export default class DoubaoChatService
     const payload = await this.makePayload(messages);
     payload.model = deploymentId;
     payload.stream = true;
-    const url = new URL('/api/v3/chat/completions', base);
+    const url = urlJoin('/api/v3/chat/completions', base);
     const response = await fetch(url.toString(), {
       method: 'POST',
       headers: {

--- a/src/intellichat/services/FireChatService.ts
+++ b/src/intellichat/services/FireChatService.ts
@@ -10,6 +10,7 @@ import Fire from 'providers/Fire';
 import useAuthStore from 'stores/useAuthStore';
 import INextChatService from './INextCharService';
 import FireReader from 'intellichat/readers/FireReader';
+import { urlJoin } from 'utils/util';
 
 const debug = Debug('5ire:intellichat:FireChatService');
 
@@ -41,7 +42,7 @@ export default class FireChatService
     if (!key) {
       throw new Error('User is not authenticated');
     }
-    const url = new URL(`/v1/chat/completions`, base);
+    const url = urlJoin(`/v1/chat/completions`, base);
     const response = await fetch(url.toString(), {
       method: 'POST',
       headers: {

--- a/src/intellichat/services/GoogleChatService.ts
+++ b/src/intellichat/services/GoogleChatService.ts
@@ -13,7 +13,7 @@ import {
 } from 'intellichat/types';
 import { isBlank } from 'utils/validators';
 import Google from 'providers/Google';
-import { getBase64, splitByImg, stripHtmlTags } from 'utils/util';
+import { getBase64, splitByImg, stripHtmlTags, urlJoin } from 'utils/util';
 import INextChatService from './INextCharService';
 import NextChatService from './NextChatService';
 import BaseReader from 'intellichat/readers/BaseReader';
@@ -247,7 +247,7 @@ export default class GoogleChatService
       )}\r\n`
     );
     const { base, key } = this.apiSettings;
-    const url = new URL(
+    const url = urlJoin(
       `/v1beta/models/${this.getModelName()}:${
         isStream ? 'streamGenerateContent' : 'generateContent'
       }?key=${key}`,

--- a/src/intellichat/services/OllamaChatService.ts
+++ b/src/intellichat/services/OllamaChatService.ts
@@ -8,6 +8,7 @@ import INextChatService from './INextCharService';
 import OpenAIChatService from './OpenAIChatService';
 import OllamaReader from 'intellichat/readers/OllamaChatReader';
 import { ITool } from 'intellichat/readers/IChatReader';
+import { urlJoin } from 'utils/util';
 
 const debug = Debug('5ire:intellichat:OllamaChatService');
 export default class OllamaChatService
@@ -56,7 +57,7 @@ export default class OllamaChatService
     const payload = await this.makePayload(messages);
     debug('Send Request, payload:\r\n', payload);
     const { base } = this.apiSettings;
-    const url = new URL('/api/chat', base);
+    const url = urlJoin('/api/chat', base);
     const response = await fetch(url.toString(), {
       method: 'POST',
       headers: {

--- a/src/intellichat/services/OpenAIChatService.ts
+++ b/src/intellichat/services/OpenAIChatService.ts
@@ -17,6 +17,7 @@ import { ITool } from 'intellichat/readers/IChatReader';
 import NextChatService from './NextChatService';
 import INextChatService from './INextCharService';
 import OpenAI from '../../providers/OpenAI';
+import { urlJoin } from 'utils/util';
 
 const debug = Debug('5ire:intellichat:OpenAIChatService');
 
@@ -206,7 +207,7 @@ export default class OpenAIChatService
     const payload = await this.makePayload(messages);
     debug('About to make a request, payload:\r\n', payload);
     const { base, key } = this.apiSettings;
-    const url = new URL('/v1/chat/completions', base);
+    const url = urlJoin('/v1/chat/completions', base);
     const response = await fetch(url.toString(), {
       method: 'POST',
       headers: {

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -426,3 +426,16 @@ export function getNormalContent(reply: string) {
 
   return replyParts.join('');
 }
+
+
+
+export function urlJoin(part: string, base: string): URL {
+  // Trim trailing slash from base
+  const trimmedBase = base.replace(/\/+$/, '');
+  
+  // Remove leading slash from part and trim trailing slashes
+  const trimmedPart = part.replace(/^\/+/, '');
+  
+  // Join with a single slash
+  return new URL(`${trimmedBase}/${trimmedPart}`);
+}


### PR DESCRIPTION
This PR fixes an issue where the path is lost when users set a custom API Base with an additional path. For example, if a user uses the following custom API Base: `https://example.com/api`, the request would be sent to `https://example.com/v1/chat/completions` instead of `https://example.com/api/v1/chat/completions`.

![image](https://github.com/user-attachments/assets/4c4659ad-af9b-4cf3-a802-d4d23ffdea15)
