### PR TITLE
add provider for LM Studio

### DIFF
--- a/src/hooks/useChatContext.ts
+++ b/src/hooks/useChatContext.ts
@@ -39,7 +39,7 @@ export default function useChatContext(): IChatContext {
     const getModel = () => {
       const { api } = useSettingsStore.getState();
       const defaultModel = { name: api.model, label: api.model } as IChatModel;
-      if (api.provider === 'Ollama') {
+      if (api.provider === 'Ollama' || api.provider === 'LMStudio') {
         return defaultModel;
       }
       let model = getChatModel(api.provider, api.model) || defaultModel;

--- a/src/intellichat/services/LMStudioChatService.ts
+++ b/src/intellichat/services/LMStudioChatService.ts
@@ -1,0 +1,31 @@
+import OpenAIChatService from './OpenAIChatService';
+import LMStudio from '../../providers/LMStudio';
+import { IChatContext, IChatRequestMessage } from 'intellichat/types';
+import INextChatService from './INextCharService';
+import { urlJoin } from 'utils/util';
+
+export default class LMStudioChatService
+  extends OpenAIChatService
+  implements INextChatService {
+  constructor(chatContext: IChatContext) {
+    super(chatContext);
+    this.provider = LMStudio;
+  }
+
+  protected async makeRequest(
+    messages: IChatRequestMessage[],
+  ): Promise<Response> {
+    const { base, key } = this.apiSettings;
+    const url = urlJoin('/chat/completions', base)
+    const response = await fetch(url.toString(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${key}`,
+      },
+      body: JSON.stringify(await this.makePayload(messages)),
+      signal: this.abortController.signal,
+    });
+    return response;
+  }
+}

--- a/src/intellichat/services/index.ts
+++ b/src/intellichat/services/index.ts
@@ -3,6 +3,7 @@ import { ProviderType } from '../../providers/types';
 import AnthropicChatService from './AnthropicChatService';
 import AzureChatService from './AzureChatService';
 import OllamaChatService from './OllamaChatService';
+import LMStudioChatService from './LMStudioChatService';
 import OpenAIChatService from './OpenAIChatService';
 import GoogleChatService from './GoogleChatService';
 import BaiduChatService from './BaiduChatService';
@@ -46,6 +47,8 @@ export default function createService(
       return new GrokChatService(chatCtx);
     case 'DeepSeek':
       return new DeepSeekChatService(chatCtx);
+    case 'LMStudio':
+      return new LMStudioChatService(chatCtx);
     default:
       throw new Error(`Invalid provider:${providerName}`);
   }

--- a/src/providers/LMStudio.ts
+++ b/src/providers/LMStudio.ts
@@ -1,0 +1,40 @@
+import { IServiceProvider } from './types';
+export default {
+  name: 'LMStudio',
+  apiBase: 'http://127.0.0.1:1234/v1',
+  currency: 'USD',
+  options: {
+    apiBaseCustomizable: true,
+  },
+  chat: {
+    apiSchema: ['base', 'model'],
+    docs: {
+      temperature:
+        'Higher values will make the output more creative and unpredictable, while lower values will make it more precise.',
+      presencePenalty:
+        "Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.",
+      topP: 'An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with topP probability mass.',
+    },
+    placeholders: {
+      base: ' http://127.0.0.1:1234/v1',
+    },
+    presencePenalty: { min: -2, max: 2, default: 0 },
+    topP: { min: 0, max: 1, default: 1 },
+    temperature: { min: 0, max: 1, default: 0.9 },
+
+    options: {
+      modelCustomizable: true,
+    },
+    models: {},
+  },
+  embedding: {
+    apiSchema: ['base', 'model'],
+    placeholders: {
+      base: ' http://127.0.0.1:1234/v1',
+    },
+    options: {
+      modelCustomizable: true,
+    },
+    models: {}
+  },
+} as IServiceProvider;

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -8,6 +8,7 @@ import ChatBro from './ChatBro';
 import Anthropic from './Anthropic';
 import Fire from './Fire';
 import Ollama from './Ollama';
+import LMStudio from './LMStudio';
 import { merge } from 'lodash';
 import Doubao from './Doubao';
 import Grok from './Grok';
@@ -27,6 +28,7 @@ export const providers: { [key: string]: IServiceProvider } = {
   Ollama,
   Doubao,
   DeepSeek,
+  LMStudio,
   '5ire':Fire,
 };
 

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -8,6 +8,7 @@ export type ProviderType =
   | 'Mistral'
   | 'DeepSeek'
   | 'Ollama'
+  | 'LMStudio'
   | 'ChatBro'
   | '5ire'
   | 'Doubao'

--- a/src/renderer/pages/settings/LMStudioModelPicker.tsx
+++ b/src/renderer/pages/settings/LMStudioModelPicker.tsx
@@ -1,0 +1,114 @@
+import { useTranslation } from 'react-i18next';
+import { useEffect, useState } from 'react';
+import { isValidHttpHRL } from 'utils/validators';
+import {
+  MenuTrigger,
+  MenuButton,
+  MenuPopover,
+  MenuList,
+  Menu,
+  MenuItem,
+} from '@fluentui/react-components';
+import ToolStatusIndicator from 'renderer/components/ToolStatusIndicator';
+
+type Item = {
+  name: string;
+  isEnabled: boolean;
+};
+
+export default function LMStudioModelPicker({
+  baseUrl,
+  onConfirm,
+}: {
+  baseUrl: string;
+  onConfirm: (modeName: string) => void;
+}) {
+  const [items, setItems] = useState<Item[]>([]);
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    if (!isValidHttpHRL(baseUrl)) {
+      setItems([
+        {
+          name: t('Common.Error.InvalidAPIBase'),
+          isEnabled: false,
+        },
+      ]);
+    } else {
+      setItems([
+        {
+          name: t('Common.Loading'),
+          isEnabled: false,
+        },
+      ]);
+      const url = new URL('/v1/models', baseUrl);
+      fetch(url.toString())
+        .then((res) => {
+          if (res.ok) {
+            res
+              .json()
+              .then((data) => {
+                setItems(
+                  data.data.map((model: any) => {
+                    return {
+                      name: model.id,
+                      isEnabled: model.id.indexOf('embed') < 0, // filter out embedding models
+                    };
+                  }),
+                );
+              })
+              .catch(() => {
+                setItems([
+                  {
+                    name: t('Common.Error.FetchFailed'),
+                    isEnabled: false,
+                  },
+                ]);
+              });
+          } else {
+            setItems([
+              {
+                name: t('Common.Error.FetchFailed'),
+                isEnabled: false,
+              },
+            ]);
+          }
+        })
+        .catch(() => {
+          setItems([
+            {
+              name: t('Common.Error.FetchFailed'),
+              isEnabled: false,
+            },
+          ]);
+        });
+    }
+    return () => setItems([]);
+  }, [baseUrl]);
+
+  return (
+    <Menu>
+      <MenuTrigger disableButtonEnhancement>
+        <MenuButton size="small" appearance="primary">
+          {t('Common.Action.Choose')}
+        </MenuButton>
+      </MenuTrigger>
+      <MenuPopover>
+        <MenuList>
+          {items.map((item: Item) => (
+            <MenuItem
+              key={item.name}
+              disabled={!item.isEnabled}
+              onClick={() => onConfirm(item.name)}
+            >
+              <div className="flex justify-start items-center gap-1">
+                <ToolStatusIndicator model={item.name} provider="LMStudio" />{' '}
+                <span> {item.name}</span>
+              </div>
+            </MenuItem>
+          ))}
+        </MenuList>
+      </MenuPopover>
+    </Menu>
+  );
+}

--- a/src/renderer/pages/settings/ModelField.tsx
+++ b/src/renderer/pages/settings/ModelField.tsx
@@ -16,6 +16,7 @@ import TooltipIcon from 'renderer/components/TooltipIcon';
 import ToolStatusIndicator from 'renderer/components/ToolStatusIndicator';
 import { isUndefined } from 'lodash';
 import OllamaModelPicker from './OllamaModelPicker';
+import LMStudioModelPicker from './LMStudioModelPicker';
 import { IChatModel, IServiceProvider } from '../../../providers/types';
 import useSettingsStore from '../../../stores/useSettingsStore';
 
@@ -89,6 +90,15 @@ export default function ModelField({
         </div>
       ),
     [provider],
+  );
+
+  const renderLMStudioModelPicker = useCallback(
+    () =>
+      provider.name === 'LMStudio' && (
+        <div className="absolute right-1 top-1">
+          <LMStudioModelPicker baseUrl={baseUrl} onConfirm={setModel} />
+        </div>
+      ),
   );
 
   return (
@@ -174,6 +184,7 @@ export default function ModelField({
               )}
 
               {renderOllamaModelPicker()}
+              {renderLMStudioModelPicker()}
             </div>
           )}
         </div>


### PR DESCRIPTION
增加一个用于 LM Studio (https://lmstudio.ai/) 的 provider
LM Studio 是另一款类似 Ollama 跑 LLM 的运行器。
虽然他提供的是 OpenAI 兼容的设计。但是需要类似 Ollama 增加 fetch 取模型名称的能力。