### PR TITLE
feat: pdf support for claude

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "5ire",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "5ire",
-      "version": "0.9.8",
+      "version": "0.9.9",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -194,6 +194,7 @@
   "Subscription.Placeholder.RedeemCode": "Redeem Code",
   "Common.GitHub": "GitHub",
   "Common.SelectImage": "Select Image",
+  "Common.SelectFile": "Select File",
   "Common.Author": "Author",
   "Common.MCPServers": "MCP Servers",
   "Common.Tools": "Tools",

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -194,6 +194,7 @@
   "Subscription.Placeholder.RedeemCode": "兑换码",
   "Common.GitHub": "GitHub",
   "Common.SelectImage": "选择图片",
+  "Common.SelectFile": "选择文件",
   "Common.Author": "作者",
   "Common.MCPServers": "遵循模型上下文协议（MCP）的服务",
   "Common.Tools": "工具",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "5ire",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "5ire",
-      "version": "0.9.8",
+      "version": "0.9.9",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -26,4 +26,5 @@ export const SUPPORTED_IMAGE_TYPES: { [key: string]: string } = {
   jpg: 'image/jpeg',
   jpeg: 'image/jpeg',
   png: 'image/png',
+  pdf: 'application/pdf'
 };

--- a/src/intellichat/services/NextChatService.ts
+++ b/src/intellichat/services/NextChatService.ts
@@ -112,7 +112,7 @@ export default abstract class NextCharService {
 
   protected getModelName() {
     const model = this.context.getModel();
-    return this.modelMapping[model.name as string] || model.name;
+    return this.modelMapping[model.label as string] || model.label;
   }
 
   public onComplete(callback: (result: any) => Promise<void>) {

--- a/src/intellichat/types.ts
+++ b/src/intellichat/types.ts
@@ -114,6 +114,7 @@ export interface IChatRequestMessageContent {
     | 'text'
     | 'image_url'
     | 'image'
+    | 'document'
     | 'function'
     | 'tool_result'
     | 'tool_use';

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -340,6 +340,10 @@ ipcMain.handle('select-image-with-base64', async () => {
           name: 'Images',
           extensions: ['jpg', 'png', 'jpeg'],
         },
+        {
+          name: 'Documents',
+          extensions: ['pdf'],
+        },
       ],
     });
     const filePath = result.filePaths[0];
@@ -361,6 +365,7 @@ ipcMain.handle('select-image-with-base64', async () => {
       );
       return null;
     }
+    const fileGroup = fileType == 'pdf' ? 'application' : 'image';
     const blob = fs.readFileSync(filePath);
     const base64 = Buffer.from(blob).toString('base64');
     return JSON.stringify({
@@ -368,7 +373,8 @@ ipcMain.handle('select-image-with-base64', async () => {
       path: filePath,
       size: fileInfo.size,
       type: fileInfo.type,
-      base64: `data:image/${fileType};base64,${base64}`,
+      useEmbed: fileType == 'pdf',
+      base64: `data:${fileGroup}/${fileType};base64,${base64}`,
     });
   } catch (err: any) {
     logging.captureException(err);

--- a/src/providers/Anthropic.ts
+++ b/src/providers/Anthropic.ts
@@ -34,6 +34,12 @@ export default {
             'image/webp',
           ],
         },
+        pdfSupport: {
+          enabled: true,
+          allowUrl: true,
+          allowBase64: true,
+          allowedMimeTypes: ['application/pdf'],
+        },
         description: `Highest level of intelligence and capability with toggleable extended thinking`,
         group: 'Claude-3.5',
       },
@@ -54,6 +60,12 @@ export default {
             'image/gif',
             'image/webp',
           ],
+          pdfSupport: {
+            enabled: true,
+            allowUrl: true,
+            allowBase64: true,
+            allowedMimeTypes: ['application/pdf'],
+          },
         },
         description: `High level of intelligence and capability`,
         group: 'Claude-3.5',
@@ -108,6 +120,12 @@ export default {
             'image/webp',
           ],
         },
+        pdfSupport: {
+          enabled: true,
+          allowUrl: true,
+          allowBase64: true,
+          allowedMimeTypes: ['application/pdf'],
+        },
         description:
           'A multilingual model with balance of intelligence and speed, strong utility, balanced for scaled deployments',
         group: 'Claude-3',
@@ -129,6 +147,12 @@ export default {
             'image/gif',
             'image/webp',
           ],
+        },
+        pdfSupport: {
+          enabled: true,
+          allowUrl: true,
+          allowBase64: true,
+          allowedMimeTypes: ['application/pdf'],
         },
         description:
           'Fastest and most compact multilingual model for near-instant responsiveness, quick and accurate targeted performance',

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -49,6 +49,14 @@ export interface IChatModelVision {
   allowBase64?: boolean;
   allowedMimeTypes?: string[];
 }
+
+export interface IChatModelPdf {
+  enabled: boolean;
+  allowUrl?: boolean;
+  allowBase64?: boolean;
+  allowedMimeTypes?: string[];
+}
+
 export interface IChatModel {
   label?: string;
   name?: string;
@@ -62,6 +70,7 @@ export interface IChatModel {
   jsonModelEnabled?: boolean;
   toolEnabled?: boolean;
   vision?: IChatModelVision;
+  pdfSupport?: IChatModelPdf;
   endpoint?: string;
   group: ChatModelGroup;
 }

--- a/src/renderer/pages/chat/Editor/index.tsx
+++ b/src/renderer/pages/chat/Editor/index.tsx
@@ -9,7 +9,7 @@ import {
 import useChatStore from 'stores/useChatStore';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@fluentui/react-components';
-import { removeTagsExceptImg, setCursorToEnd } from 'utils/util';
+import { removeTagsExceptMediaTags, setCursorToEnd } from 'utils/util';
 import { debounce } from 'lodash';
 import { tempChatId } from 'consts';
 import Spinner from '../../../components/Spinner';
@@ -83,7 +83,7 @@ export default function Editor({
           } else {
             event.preventDefault();
             setSubmitted(true);
-            onSubmit(removeTagsExceptImg(editorRef.current?.innerHTML || ''));
+            onSubmit(removeTagsExceptMediaTags(editorRef.current?.innerHTML || ''));
             // @ts-ignore
             editorRef.current.innerHTML = '';
             editStage(chat.id, { input: '' });


### PR DESCRIPTION
Since you updated the model selector already, I've hereby only fixed the pdf support. 

For adding it to other models, update the model json (add pdfSupport) and the ChatService for logic. I only have access to claude so I'm not able to test other models