### PR TITLE
Draft: fix error when mcp tool doesn't exist

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -584,12 +584,36 @@ ipcMain.handle('mcp-deactivate', async (_, clientName: string) => {
   return await mcp.deactivate(clientName);
 });
 ipcMain.handle('mcp-list-tools', async (_, name: string) => {
-  return await mcp.listTools(name);
+  try {
+    return await mcp.listTools(name);
+  } catch (error: any) {
+    logging.error('Error listing MCP tools:', error);
+    return {
+      tools: [],
+      error: {
+        message: error.message || 'Unknown error listing tools',
+        code: 'unexpected_error',
+      },
+    };
+  }
 });
 ipcMain.handle(
   'mcp-call-tool',
   async (_, args: { client: string; name: string; args: any }) => {
-    return await mcp.callTool(args);
+    try {
+      return await mcp.callTool(args);
+    } catch (error: any) {
+      logging.error('Error invoking MCP tool:', error);
+      return {
+        isError: true,
+        content: [
+          {
+            error: error.message || 'Unknown error calling tool',
+            code: 'unexpected_error',
+          },
+        ],
+      };
+    }
   },
 );
 ipcMain.handle('mcp-get-config', () => {


### PR DESCRIPTION
cannot get dev environment working.

try fix #247

hypothesis:
- when a message is sent, the application processes it and may identify MCP tools to call using listTools in mcp.ts
- if mcp client has issues with fetching tools, it throws an error
- error is not caught thus crashing the message request

happens regardless of whether the user's message actually needs to use tools, the program initially fetches the list of tools to make available to the LLM

the fix: if a client fails during listTools, we still return the tools from successful clients, and the message can be sent to the AI model