### PR TITLE
fix(google): move API key from URL query parameter to x-goog-api-key header

### DIFF
--- a/src/intellichat/services/GoogleChatService.ts
+++ b/src/intellichat/services/GoogleChatService.ts
@@ -411,11 +411,12 @@ export default class GoogleChatService
     const url = urlJoin(
       `/v1beta/models/${this.getModelName()}:${
         isStream ? 'streamGenerateContent' : 'generateContent'
-      }?key=${provider.apiKey.trim()}`,
+      }`,
       provider.apiBase.trim(),
     );
     const headers = {
       'Content-Type': 'application/json',
+      'x-goog-api-key': provider.apiKey.trim(),
     };
 
     return this.makeHttpRequest(url, headers, payload, isStream);

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -76,7 +76,7 @@ export async function countTokensOfGemini(
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'x-goog-api-key': apiKey,
+        'x-goog-api-key': apiKey.trim(),
       },
       body: JSON.stringify({ contents: messages }),
     },

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -71,11 +71,12 @@ export async function countTokensOfGemini(
   model: string,
 ) {
   const response = await fetch(
-    `${apiBase}/v1beta/models/${model}:countTokens?key=${apiKey}`,
+    `${apiBase}/v1beta/models/${model}:countTokens`,
     {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        'x-goog-api-key': apiKey,
       },
       body: JSON.stringify({ contents: messages }),
     },


### PR DESCRIPTION
## Summary

The Google API key is currently passed as a URL query parameter (`?key=...`) in two files:

- `src/intellichat/services/GoogleChatService.ts` — chat completions and streaming
- `src/utils/token.ts` — token counting via the Gemini API

This is a CWE-200 (Exposure of Sensitive Information) concern. API keys embedded in URLs are recorded in places the user does not control and cannot easily audit:

1. **Proxy and CDN access logs** — corporate proxies, ISP-level transparent proxies, and CDN edge nodes routinely log full request URLs including query strings.
2. **Server-side access logs** — Google's own infrastructure logs the full URL; while Google's retention policies are reasonable, the key is still transmitted in a loggable position.
3. **Browser/Electron network internals** — DevTools network panels, `chrome://net-export`, and crash reports may capture full URLs.
4. **Referrer headers** — if any redirect occurs during the request, the full URL (with key) can leak in the `Referer` header to the redirect target.

Google themselves recommend using the `x-goog-api-key` HTTP header instead of the query parameter for exactly these reasons. HTTP headers are not logged by proxies and intermediaries by default, and are never included in referrer headers.

## Fix

This PR removes the API key from the URL query string and sends it in the `x-goog-api-key` request header in both affected files. This is a supported authentication method for Google's Generative AI APIs.

**`GoogleChatService.ts`**: Removed `?key=${provider.apiKey.trim()}` from the URL template and added `'x-goog-api-key': provider.apiKey.trim()` to the headers object.

**`token.ts`**: Same change for the `countTokens` fetch call — key moved from URL to header.

## Testing

- Verified the fix compiles without errors (`npm run build` passes).
- Confirmed that the `x-goog-api-key` header is the documented authentication method for Google Generative AI REST endpoints per [Google's API documentation](https://ai.google.dev/gemini-api/docs/api-key).
- Reviewed both call sites to ensure no other code path reconstructs the key into the URL.

## Adversarial review

Before submitting, we considered whether this exposure is actually exploitable given that 5ire is a desktop Electron app where the user provides their own key. The key concern isn't that another user of the app gains access — it's that third-party infrastructure (corporate proxies, ISP transparent proxies, CDN logs) that the user's traffic traverses can silently capture the key from logged URLs. The user has no visibility into or control over these logs. Moving the key to a header is a low-risk, high-value hardening change that aligns with Google's own recommendation.

## Reproduction

To observe the current behavior, inspect outgoing network requests from 5ire (e.g., via Electron DevTools Network tab or a local proxy like mitmproxy). The Google API key appears in the request URL query string:

```
GET /v1beta/models/gemini-pro:generateContent?key=AIzaSy... HTTP/1.1
```

After this fix, the URL contains no key and the request instead includes:

```
x-goog-api-key: AIzaSy...
```

---



<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a security vulnerability (CWE-200) by moving the Google API key from URL query parameters to the `x-goog-api-key` HTTP header in two locations: the Google chat service for completions/streaming and the token counting utility. This prevents the API key from being exposed in proxy logs, server access logs, browser network tools, and referrer headers, aligning with Google's recommended authentication method.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/intellichat/services/GoogleChatService.ts` |
| 2 | `src/utils/token.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved authentication for Gemini integrations: API keys are now sent more securely in request headers for both content generation and token-counting flows, maintaining streaming and non-streaming behavior and preserving existing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanbingxyz/5ire/pull/425)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->