### PR TITLE
fix(mcp): prevent argv smuggling in MCP server endpoint serialization

### DIFF
--- a/src/main/services/legacy-data-migrator.ts
+++ b/src/main/services/legacy-data-migrator.ts
@@ -11,6 +11,7 @@ import { Stateful } from "@/main/internal/stateful";
 import { LegacyServersConfigLoader } from "@/main/services/legacy-servers-config-loader";
 import { LegacyVectorDatabaseLoader } from "@/main/services/legacy-vector-database-loader";
 import { Logger } from "@/main/services/logger";
+import { formatCommandLine } from "@/utils/command-line";
 
 /**
  * Responsible for migrating old database structures to new database structures
@@ -390,7 +391,7 @@ export class LegacyDataMigrator extends Stateful.Persistable<LegacyDataMigrator.
         if (server.command) {
           data = {
             transport: "stdio",
-            endpoint: [server.command, ...(server.args || [])].join(" "),
+            endpoint: formatCommandLine([server.command, ...(server.args || [])]),
             label: server.name || server.key,
             config: server.env || {},
             description: server.description,

--- a/src/renderer/pages/tool/ServerInstaller.tsx
+++ b/src/renderer/pages/tool/ServerInstaller.tsx
@@ -20,6 +20,7 @@ import useMarkdown from "@/hooks/useMarkdown";
 import useToast from "@/hooks/useToast";
 import type { MCPServersManager } from "@/main/services/mcp-servers-manager";
 import ListInput from "@/renderer/components/ListInput";
+import { formatCommandLine } from "@/utils/command-line";
 import { fillArgs, FillEnvOrHeaders as fillConfig, getParameters } from "@/utils/mcp";
 
 const ServerTemplateBaseSchema = z.object({
@@ -335,7 +336,7 @@ export const ServerInstaller = forwardRef<ServerInstallerInstance>((_, ref) => {
     };
 
     if (templateRendered.type === "local") {
-      options.endpoint = [templateRendered.command, templateRendered.arguments].flat().join(" ");
+      options.endpoint = formatCommandLine([templateRendered.command, ...templateRendered.arguments]);
     } else {
       options.endpoint = templateRendered.url;
     }

--- a/src/utils/command-line.ts
+++ b/src/utils/command-line.ts
@@ -91,3 +91,27 @@ export function parseCommandLine(input: string): string[] {
 
   return tokens;
 }
+
+/**
+ * Serializes an argv array into a single command-line string that, when fed
+ * back through {@link parseCommandLine}, yields the original argv.
+ *
+ * This is required wherever an argv list (e.g. an MCP stdio server's command +
+ * arguments) is collapsed into the single `endpoint` string stored in the
+ * database. Naively joining with spaces (`args.join(" ")`) allows an attacker
+ * who controls any argument value (for instance via a deep link or marketplace
+ * template) to smuggle additional arguments to the spawned process by
+ * embedding whitespace, quotes, or backslashes in their value (CWE-78).
+ *
+ * Each argument is wrapped in double quotes, with embedded backslashes and
+ * double quotes escaped, so that {@link parseCommandLine} reconstructs the
+ * exact same argv. Empty strings round-trip as `""`.
+ */
+export function formatCommandLine(args: readonly string[]): string {
+  return args
+    .map((arg) => {
+      const escaped = arg.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+      return `"${escaped}"`;
+    })
+    .join(" ");
+}

--- a/test/utils/command-line-roundtrip.test.ts
+++ b/test/utils/command-line-roundtrip.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "@jest/globals";
+import { formatCommandLine, parseCommandLine } from "../../src/utils/command-line";
+
+describe("utils/command-line round-trip (argv smuggling protection)", () => {
+  const cases: Array<[string, string[]]> = [
+    ["plain", ["npx", "-y", "@modelcontextprotocol/server"]],
+    ["arg with space", ["python", "C:\\path with spaces\\script.py", "--flag"]],
+    ["arg with double quote", ["echo", 'hello "world"']],
+    ["arg with single quote", ["echo", "it's"]],
+    ["arg with backslash", ["python", "C:\\foo\\bar"]],
+    [
+      "argv smuggling attempt: extra args injected via space",
+      ["mcp-server", "--config=safe", "--inject extra-arg --bad"],
+    ],
+    [
+      "argv smuggling attempt: shell metacharacters",
+      ["mcp-server", "; rm -rf ~", "$(whoami)", "`id`", "&& touch /tmp/pwned"],
+    ],
+  ];
+
+  for (const [name, args] of cases) {
+    test(`round-trips: ${name}`, () => {
+      const serialized = formatCommandLine(args);
+      expect(parseCommandLine(serialized)).toEqual(args);
+    });
+  }
+});


### PR DESCRIPTION
## Vulnerability Summary

**CWE-78 (OS Command Injection) — Argv smuggling via unsafe command-line serialization in MCP server installation**

When a user installs an MCP server through a deep link (`5ire://`) or marketplace template, the server's command and arguments are serialized into a single `endpoint` string for storage. The existing code joins them naively with spaces:

```typescript
endpoint: [server.command, ...(server.args || [])].join(" ")
```

Later, when the MCP server is spawned, `parseCommandLine()` splits this string back into an argv array. Because the serialization doesn't escape or quote arguments, an attacker who controls any argument value (e.g. via a crafted deep link) can embed spaces, quotes, or backslashes to smuggle additional arguments into the spawned process.

**Affected files:**
- `src/renderer/pages/tool/ServerInstaller.tsx` (line 338) — handles installation from templates/deep links
- `src/main/services/legacy-data-migrator.ts` (line 393) — handles legacy config migration

**Data flow:**
1. Attacker crafts a `5ire://` deep link containing a malicious MCP server config with crafted arguments
2. `deep-link-handler.ts#handleInstallServer()` parses the URL and passes the config to `ServerInstaller`
3. `ServerInstaller` serializes `[command, ...arguments].join(" ")` into `endpoint`
4. On next use, `parseCommandLine(endpoint)` splits the string — but the split doesn't match the original argv because the join didn't preserve token boundaries
5. The spawned MCP server process receives attacker-controlled extra arguments

**Precondition:** Victim clicks a malicious `5ire://` deep link. No other authentication or privilege is required.

## Fix Description

This PR introduces `formatCommandLine()` — the inverse of the existing `parseCommandLine()`. It wraps each argument in double quotes, escaping embedded backslashes and double quotes, so that the serialized string round-trips correctly through `parseCommandLine()`.

The two call sites that previously used `.join(" ")` now use `formatCommandLine()` instead.

The fix is minimal (55 lines added across 4 files) and doesn't change any existing behavior for arguments that don't contain special characters — it only adds proper quoting for those that do.

## PoC — Argv Smuggling

Using the existing `parseCommandLine` from `src/utils/command-line.ts`:

```typescript
// Simulating the VULNERABLE code path:
const command = "mcp-server";
const args = ["--config=safe", "--inject extra-arg --bad"];

// Old (vulnerable): naive join
const endpointOld = [command, ...args].join(" ");
// => "mcp-server --config=safe --inject extra-arg --bad"

parseCommandLine(endpointOld);
// => ["mcp-server", "--config=safe", "--inject", "extra-arg", "--bad"]
//    ^^^ 5 tokens instead of 3 — attacker smuggled 2 extra arguments

// New (fixed): proper quoting
const endpointNew = formatCommandLine([command, ...args]);
// => '"mcp-server" "--config=safe" "--inject extra-arg --bad"'

parseCommandLine(endpointNew);
// => ["mcp-server", "--config=safe", "--inject extra-arg --bad"]
//    ^^^ 3 tokens — matches original argv exactly
```

A deep link like `5ire://install-server?command=mcp-server&args=--inject%20extra-arg%20--bad` would trigger this via the `#handleInstallServer` handler in `deep-link-handler.ts`.

## Tests

Added `test/utils/command-line-roundtrip.test.ts` with 7 test cases covering:
- Plain arguments (no special characters)
- Arguments with spaces, double quotes, single quotes, backslashes
- Argv smuggling attempts (extra args via embedded spaces)
- Shell metacharacters (`;`, `$()`, backticks, `&&`)

All tests verify that `parseCommandLine(formatCommandLine(argv))` returns the original argv.

## Adversarial Review

Before submitting, we considered whether existing protections prevent exploitation. The deep link handler (`#handleInstallServer`) does not validate or sanitize argument values before passing them to `ServerInstaller`. The `parseCommandLine` function is a proper tokenizer that handles quoting — but it can only preserve boundaries that were encoded during serialization. Since the old code never quoted anything, any argument containing whitespace or quote characters would be mis-parsed. There are no other sanitization layers between the deep link input and the `.join(" ")` call.

---



<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a **CWE-78 command injection vulnerability** where MCP server command-line arguments were naively joined with spaces during serialization, allowing attackers to smuggle additional arguments via crafted deep links. The fix introduces `formatCommandLine()`, which properly quotes and escapes each argument so that the round-trip through `parseCommandLine()` preserves the original argv array. The two vulnerable call sites in `ServerInstaller.tsx` and `legacy-data-migrator.ts` now use the safe serialization function instead of `.join(" ")`. This prevents argument injection attacks where malicious deep links could cause the application to spawn MCP server processes with attacker-controlled arguments.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `test/utils/command-line-roundtrip.test.ts` |
| 2 | `src/utils/command-line.ts` |
| 3 | `src/renderer/pages/tool/ServerInstaller.tsx` |
| 4 | `src/main/services/legacy-data-migrator.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Fixed command-line argument handling in server configuration and legacy data migration to properly preserve arguments containing spaces, quotes, and special characters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanbingxyz/5ire/pull/426)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->