### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/src/intellichat/services/LiteLLMChatService.ts
+++ b/src/intellichat/services/LiteLLMChatService.ts
@@ -1,0 +1,11 @@
+import type { IChatContext } from "intellichat/types";
+import LiteLLM from "../../providers/LiteLLM";
+import type INextChatService from "./INextCharService";
+import OpenAIChatService from "./OpenAIChatService";
+
+export default class LiteLLMChatService extends OpenAIChatService implements INextChatService {
+  constructor(name: string, chatContext: IChatContext) {
+    super(name, chatContext);
+    this.provider = LiteLLM;
+  }
+}

--- a/src/intellichat/services/index.ts
+++ b/src/intellichat/services/index.ts
@@ -1,58 +1,61 @@
-import Debug from 'debug';
-import { IChatContext } from '../types';
-import AnthropicChatService from './AnthropicChatService';
-import AzureChatService from './AzureChatService';
-import OllamaChatService from './OllamaChatService';
-import LMStudioChatService from './LMStudioChatService';
-import OpenAIChatService from './OpenAIChatService';
-import GoogleChatService from './GoogleChatService';
-import BaiduChatService from './BaiduChatService';
-import MoonshotChatService from './MoonshotChatService';
-import MistralChatService from './MistralChatService';
-import FireChatService from './FireChatService';
-import DoubaoChatService from './DoubaoChatService';
-import GrokChatService from './GrokChatService';
-import DeepSeekChatService from './DeepSeekChatService';
-import ZhipuChatService from './ZhipuChatService';
-import INextChatService from './INextCharService';
-import PerplexityChatService from './PerplexityChatService';
+import Debug from "debug";
+import type { IChatContext } from "../types";
+import AnthropicChatService from "./AnthropicChatService";
+import AzureChatService from "./AzureChatService";
+import BaiduChatService from "./BaiduChatService";
+import DeepSeekChatService from "./DeepSeekChatService";
+import DoubaoChatService from "./DoubaoChatService";
+import FireChatService from "./FireChatService";
+import GoogleChatService from "./GoogleChatService";
+import GrokChatService from "./GrokChatService";
+import type INextChatService from "./INextCharService";
+import LiteLLMChatService from "./LiteLLMChatService";
+import LMStudioChatService from "./LMStudioChatService";
+import MistralChatService from "./MistralChatService";
+import MoonshotChatService from "./MoonshotChatService";
+import OllamaChatService from "./OllamaChatService";
+import OpenAIChatService from "./OpenAIChatService";
+import PerplexityChatService from "./PerplexityChatService";
+import ZhipuChatService from "./ZhipuChatService";
 
-const debug = Debug('5ire:intellichat:ChatService');
+const debug = Debug("5ire:intellichat:ChatService");
 
 export default function createService(chatCtx: IChatContext): INextChatService {
   const provider = chatCtx.getProvider();
-  debug('CreateService', provider.name);
+  debug("CreateService", provider.name);
   switch (provider.name) {
-    case 'Anthropic':
+    case "Anthropic":
       return new AnthropicChatService(provider.name, chatCtx);
-    case 'OpenAI':
+    case "OpenAI":
       return new OpenAIChatService(provider.name, chatCtx);
-    case 'Azure':
+    case "Azure":
       return new AzureChatService(provider.name, chatCtx);
-    case 'Google':
+    case "Google":
       return new GoogleChatService(provider.name, chatCtx);
-    case 'Baidu':
+    case "Baidu":
       return new BaiduChatService(provider.name, chatCtx);
-    case 'Mistral':
+    case "Mistral":
       return new MistralChatService(provider.name, chatCtx);
-    case 'Moonshot':
+    case "Moonshot":
       return new MoonshotChatService(provider.name, chatCtx);
-    case 'Ollama':
+    case "Ollama":
       return new OllamaChatService(provider.name, chatCtx);
-    case '5ire':
+    case "5ire":
       return new FireChatService(provider.name, chatCtx);
-    case 'Doubao':
+    case "Doubao":
       return new DoubaoChatService(provider.name, chatCtx);
-    case 'Grok':
+    case "Grok":
       return new GrokChatService(provider.name, chatCtx);
-    case 'DeepSeek':
+    case "DeepSeek":
       return new DeepSeekChatService(provider.name, chatCtx);
-    case 'LMStudio':
+    case "LMStudio":
       return new LMStudioChatService(provider.name, chatCtx);
-    case 'Perplexity':
+    case "Perplexity":
       return new PerplexityChatService(provider.name, chatCtx);
-    case 'Zhipu':
+    case "Zhipu":
       return new ZhipuChatService(provider.name, chatCtx);
+    case "LiteLLM":
+      return new LiteLLMChatService(provider.name, chatCtx);
     default:
       return new OpenAIChatService(provider.name, chatCtx);
   }

--- a/src/providers/LiteLLM.ts
+++ b/src/providers/LiteLLM.ts
@@ -1,0 +1,33 @@
+import type { IServiceProvider } from "./types";
+
+export default {
+  name: "LiteLLM",
+  apiBase: "http://localhost:4000/v1",
+  currency: "USD",
+  options: {
+    apiBaseCustomizable: true,
+    apiKeyCustomizable: true,
+    isApiKeyOptional: true,
+    modelsEndpoint: "/models",
+  },
+  chat: {
+    apiSchema: ["base", "key", "proxy"],
+    docs: {
+      temperature:
+        "Higher values will make the output more creative and unpredictable, while lower values will make it more precise.",
+      presencePenalty:
+        "Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.",
+      topP: "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with topP probability mass.",
+    },
+    placeholders: {
+      base: "localhost:4000/v1",
+    },
+    presencePenalty: { min: -2, max: 2, default: 0 },
+    topP: { min: 0, max: 1, default: 1 },
+    temperature: { min: 0, max: 2, default: 1 },
+    options: {
+      modelCustomizable: true,
+    },
+    models: [],
+  },
+} as IServiceProvider;

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,20 +1,21 @@
-import { ProviderType, IServiceProvider } from './types';
-import Azure from './Azure';
-import Baidu from './Baidu';
-import OpenAI from './OpenAI';
-import Google from './Google';
-import Moonshot from './Moonshot';
-import Anthropic from './Anthropic';
-import Fire from './Fire';
-import Ollama from './Ollama';
-import LMStudio from './LMStudio';
-import Doubao from './Doubao';
-import Grok from './Grok';
-import DeepSeek from './DeepSeek';
-import Mistral from './Mistral';
-import Perplexity from './Perplexity';
-import AI302 from './AI302';
-import Zhipu from './Zhipu';
+import AI302 from "./AI302";
+import Anthropic from "./Anthropic";
+import Azure from "./Azure";
+import Baidu from "./Baidu";
+import DeepSeek from "./DeepSeek";
+import Doubao from "./Doubao";
+import Fire from "./Fire";
+import Google from "./Google";
+import Grok from "./Grok";
+import LiteLLM from "./LiteLLM";
+import LMStudio from "./LMStudio";
+import Mistral from "./Mistral";
+import Moonshot from "./Moonshot";
+import Ollama from "./Ollama";
+import OpenAI from "./OpenAI";
+import Perplexity from "./Perplexity";
+import type { IServiceProvider, ProviderType } from "./types";
+import Zhipu from "./Zhipu";
 
 export const providers: { [key: string]: IServiceProvider } = {
   OpenAI,
@@ -31,13 +32,12 @@ export const providers: { [key: string]: IServiceProvider } = {
   LMStudio,
   Zhipu,
   Perplexity,
-  '302.AI': AI302,
-  '5ire': Fire,
+  "302.AI": AI302,
+  "5ire": Fire,
+  LiteLLM,
 };
 
-export function getBuiltInProvider(
-  providerName: ProviderType,
-): IServiceProvider {
+export function getBuiltInProvider(providerName: ProviderType): IServiceProvider {
   return providers[providerName];
 }
 

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,21 +1,22 @@
 export type ProviderType =
-  | 'OpenAI'
-  | 'Google'
-  | 'Azure'
-  | 'Baidu'
-  | 'Anthropic'
-  | 'Moonshot'
-  | 'Mistral'
-  | 'DeepSeek'
-  | 'Ollama'
-  | 'LMStudio'
-  | 'ChatBro'
-  | '5ire'
-  | 'Doubao'
-  | 'Grok'
-  | '302.AI'
-  | 'Zhipu'
-  | 'Perplexity';
+  | "OpenAI"
+  | "Google"
+  | "Azure"
+  | "Baidu"
+  | "Anthropic"
+  | "Moonshot"
+  | "Mistral"
+  | "DeepSeek"
+  | "Ollama"
+  | "LMStudio"
+  | "ChatBro"
+  | "5ire"
+  | "Doubao"
+  | "Grok"
+  | "302.AI"
+  | "Zhipu"
+  | "Perplexity"
+  | "LiteLLM";
 
 export interface INumberRange {
   min: number;
@@ -111,7 +112,7 @@ export interface IServiceProvider {
   apiBase: string;
   apiKey?: string;
   apiVersion?: string;
-  currency: 'USD' | 'CNY';
+  currency: "USD" | "CNY";
   options: {
     apiBaseCustomizable?: boolean;
     apiKeyCustomizable?: boolean;
@@ -166,7 +167,7 @@ export interface IChatProviderConfig {
   apiKey: string;
   apiSecret?: string;
   apiVersion?: string;
-  currency: 'USD' | 'CNY';
+  currency: "USD" | "CNY";
   modelExtras?: string[];
   modelsEndpoint?: string;
   models: IChatModelConfig[];


### PR DESCRIPTION
## Summary

Add [LiteLLM](https://github.com/BerriAI/litellm) as a built-in AI gateway provider, giving users access to 100+ LLM providers (AWS Bedrock, Google Vertex AI, Azure, Cohere, Replicate, HuggingFace, and more) through a single OpenAI-compatible proxy interface with automatic model discovery.

## Changes

| File | Change |
|------|--------|
| `src/providers/LiteLLM.ts` | New provider config with `/v1/models` auto-discovery |
| `src/intellichat/services/LiteLLMChatService.ts` | Chat service extending OpenAIChatService (LiteLLM proxy is OpenAI-compatible) |
| `src/providers/types.ts` | Added `'LiteLLM'` to `ProviderType` union |
| `src/providers/index.ts` | Registered provider in the providers map |
| `src/intellichat/services/index.ts` | Added `'LiteLLM'` case to service factory switch |

## Implementation details

- Follows the exact same pattern as LMStudio and Grok - a thin chat service that extends `OpenAIChatService` and sets the provider config
- Default proxy URL: `http://localhost:4000/v1` (standard LiteLLM proxy address)
- `modelsEndpoint: "/models"` enables auto-discovery, same pattern as Ollama (`/api/tags`) and LMStudio (`/models`)
- API key is optional (`isApiKeyOptional: true`) since LiteLLM proxy may run without auth locally
- Both API base URL and API key are user-customizable
- Empty built-in models array since models come from the proxy dynamically

## Tests

**1. Model auto-discovery** (`GET /v1/models`):
```json
{
    "data": [
        {
            "id": "anthropic/claude-sonnet-4-6",
            "object": "model",
            "created": 1677610602,
            "owned_by": "openai"
        }
    ],
    "object": "list"
}
```

**2. Chat completion** (non-streaming):
```json
{
    "id": "chatcmpl-a8dd8b54-56a2-4c89-9ccb-11e1f0cda1f9",
    "model": "claude-sonnet-4-6",
    "object": "chat.completion",
    "choices": [
        {
            "finish_reason": "stop",
            "index": 0,
            "message": {
                "content": "4",
                "role": "assistant"
            }
        }
    ],
    "usage": {
        "completion_tokens": 5,
        "prompt_tokens": 20,
        "total_tokens": 25
    }
}
```

**3. Streaming** (SSE):
```
data: {"id":"chatcmpl-591c3b5e-...","model":"claude-sonnet-4-6","choices":[{"index":0,"delta":{"content":"Hello!","role":"assistant"}}]}
data: {"id":"chatcmpl-591c3b5e-...","choices":[{"finish_reason":"stop","index":0,"delta":{}}]}
data: [DONE]
```

**4. Biome lint**: `npx @biomejs/biome check` passes clean on all new files.

Tested with LiteLLM proxy routing to Azure Foundry (Claude Sonnet 4.6).

## How to use

1. Start a LiteLLM proxy ([quick start](https://docs.litellm.ai/docs/proxy/quick_start)):
   ```bash
   litellm --model anthropic/claude-sonnet-4-6
   ```
2. In 5ire, select **LiteLLM** from the provider list
3. Set the proxy URL (defaults to `http://localhost:4000/v1`)
4. Click the refresh button to auto-discover available models
5. Start chatting

## Risk / Compatibility

- **Additive only** - no existing providers or code paths are modified
- Follows established patterns (identical structure to LMStudio/Grok providers)
- The chat service is 11 lines of code; the provider config is 35 lines

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds LiteLLM as a new AI gateway provider, enabling access to 100+ LLM providers through a single OpenAI-compatible proxy interface. The implementation follows the established pattern used by similar providers like LMStudio and Grok, extending `OpenAIChatService` to leverage OpenAI compatibility. The provider supports automatic model discovery via the `/v1/models` endpoint, has an optional API key (useful for local development), and defaults to `http://localhost:4000/v1` as the proxy URL. Both the API base URL and API key are customizable by users.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/providers/types.ts` |
| 2 | `src/providers/LiteLLM.ts` |
| 3 | `src/intellichat/services/LiteLLMChatService.ts` |
| 4 | `src/providers/index.ts` |
| 5 | `src/intellichat/services/index.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added LiteLLM provider support. Users can now configure and use LiteLLM as a chat service with fully customizable API settings, optional API key authentication, adjustable model parameters including temperature, presence penalty, and top-P settings, plus proxy configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->